### PR TITLE
Parameterized paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+### 0.3
+
+  - routing now happens not via page.route function, but by reading page.routes hash
+  - page.routes hash can contain parameterized routes (e.g. /posts/:post_id)
+  - a single route pattern can contain multiple slashes in it
+
 ### 0.2
 
   - AMD support

--- a/navstack.js
+++ b/navstack.js
@@ -25,6 +25,7 @@
 
             if (this._stack) {
                 for (var i = 0; i < this._stack.length; i++) {
+                    console.log("calling with true");
                     this._willNavigateAway({
                         up: true
                     });

--- a/navstack.js
+++ b/navstack.js
@@ -25,7 +25,6 @@
 
             if (this._stack) {
                 for (var i = 0; i < this._stack.length; i++) {
-                    console.log("calling with true");
                     this._willNavigateAway({
                         up: true
                     });

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -20,7 +20,8 @@ buster.assertions.add("pageNavigatedTo", {
 buster.assertions.add("pageRoutedTo", {
     assert: function (page, expected) {
         this.wtf = expected;
-        return page.route.getCall(0).args[0] === expected;
+        var routeHandler = page[page.routes[expected]];
+        return routeHandler.calledOnce;
     },
     assertMessage: "Expected page to be routed to ${wtf}"
 });


### PR DESCRIPTION
``` JavaScript
var page = {

  routes: {
    "/post/:id": "handlePost",
    "/about": "handleAbout",
    "/route/with/multiple/slashes": "handleThis",
    "/": "handleIndex"
  },

  handlePost: function (params) {
    var post = Post.find(params.id);
    return someView({
      model: post
    }};
  },

  ...

}
```
